### PR TITLE
Mark JS standard warnings, add semistandard maker.

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -36,7 +36,13 @@ endfunction
 
 function! neomake#makers#ft#javascript#standard()
     return {
-        \ 'errorformat': '  %f:%l:%c: %m'
+        \ 'errorformat': '%W  %f:%l:%c: %m'
+        \ }
+endfunction
+
+function! neomake#makers#ft#javascript#semistandard()
+    return {
+        \ 'errorformat': '%W  %f:%l:%c: %m'
         \ }
 endfunction
 


### PR DESCRIPTION
Based on discussion in https://github.com/neomake/neomake/pull/345
